### PR TITLE
Set checkout fetch-depth=0 in submodule example

### DIFF
--- a/.github/workflows/hosted-ninja-vcpkg_submod.yml
+++ b/.github/workflows/hosted-ninja-vcpkg_submod.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          fetch-depth: 0
 
       - uses: lukka/get-cmake@latest
       - name: dir


### PR DESCRIPTION
I had to set this parameter to avoid the following vcpkg error (vcpkg at 2023.01.09):

```
Error: while checking out port catch2 with git tree 414a5ef901a6f05c85b4f19ff2d0d216933a65b1
Error: Failed to tar port directory
error: tar failed with exit code: (128).
fatal: not a tree object: 414a5ef901a6f05c85b4f19ff2d0d216933a65b1

vcpkg was cloned as a shallow repository in: /<build-dir>/external/vcpkg/.git
Try again with a full vcpkg clone.
```